### PR TITLE
Add stream/sink combinators and move the limiter instead of taking it by &mut

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,15 +23,13 @@
 //!
 //! let mut lim = DirectRateLimiter::<LeakyBucket>::per_second(NonZeroU32::new(1).unwrap());
 //! {
-//!     let mut lim = lim.clone();
-//!     let ratelimit_future = Ratelimit::new(&mut lim);
+//!     let ratelimit_future = Ratelimit::new(lim.clone());
 //!     let future_of_3 = ratelimit_future.and_then(|_| {
 //!         Ok(3)
 //!     });
 //! }
 //! {
-//!     let mut lim = lim.clone();
-//!     let ratelimit_future = Ratelimit::new(&mut lim);
+//!     let ratelimit_future = Ratelimit::new(lim.clone());
 //!     let future_of_4 = ratelimit_future.and_then(|_| {
 //!         Ok(4)
 //!     });
@@ -60,16 +58,16 @@ use ratelimit_meter::{algorithms::Algorithm, DirectRateLimiter, NonConformance};
 use std::io;
 
 /// The rate-limiter as a future.
-pub struct Ratelimit<'a, A: Algorithm>
+pub struct Ratelimit<A: Algorithm>
 where
     <A as Algorithm>::NegativeDecision: NonConformance,
 {
     delay: Delay,
-    limiter: &'a mut DirectRateLimiter<A>,
+    limiter: DirectRateLimiter<A>,
     first_time: bool,
 }
 
-impl<'a, A: Algorithm> Ratelimit<'a, A>
+impl<A: Algorithm> Ratelimit<A>
 where
     <A as Algorithm>::NegativeDecision: NonConformance,
 {
@@ -87,7 +85,7 @@ where
 
     /// Creates a new future that resolves successfully as soon as the
     /// rate limiter allows it.
-    pub fn new(limiter: &'a mut DirectRateLimiter<A>) -> Self {
+    pub fn new(limiter: DirectRateLimiter<A>) -> Self {
         Ratelimit {
             delay: Delay::new(Default::default()),
             first_time: true,
@@ -96,7 +94,7 @@ where
     }
 }
 
-impl<'a, A: Algorithm> Future for Ratelimit<'a, A>
+impl<A: Algorithm> Future for Ratelimit<A>
 where
     <A as Algorithm>::NegativeDecision: NonConformance,
 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,6 +57,9 @@ use futures_timer::Delay;
 use ratelimit_meter::{algorithms::Algorithm, DirectRateLimiter, NonConformance};
 use std::io;
 
+pub mod sink;
+pub mod stream;
+
 /// The rate-limiter as a future.
 pub struct Ratelimit<A: Algorithm>
 where
@@ -91,6 +94,15 @@ where
             first_time: true,
             limiter,
         }
+    }
+
+    /// Reset this future (but not the underlying rate-limiter) to its initial state.
+    ///
+    /// This allows re-using the same future to rate-limit multiple items.
+    /// Calling this method should be semantically equivalent to replacing this `Ratelimit`
+    /// with a newly created `Ratelimit` using the same limiter.
+    pub fn restart(&mut self) {
+        self.first_time = true;
     }
 }
 

--- a/src/sink.rs
+++ b/src/sink.rs
@@ -8,8 +8,12 @@ use std::io;
 pub trait SinkExt: Sink {
     /// Limits the rate at which items can be put into the current sink.
     ///
-    /// Note that this combinator does not buffer any items internally but
-    /// instead limits `start_send` calls to the underlying sink.
+    /// Note that this combinator limits the rate at which it accepts items,
+    /// not necessarily the rate at which the underlying sink does.
+    /// The combinator will buffer at most one item in order to adhere to the
+    /// given limiter. I.e. if it already has an item buffered and needs to
+    /// wait, it will not accept any more items until the underlying stream has
+    /// accepted the current item.
     fn sink_ratelimit<A: Algorithm>(self, limiter: DirectRateLimiter<A>) -> Ratelimited<Self, A>
     where
         Self: Sized,
@@ -25,7 +29,7 @@ impl<S: Sink> SinkExt for S {
         Ratelimited {
             inner: self,
             ratelimit: Ratelimit::new(limiter),
-            check_limit: true,
+            buf: None,
         }
     }
 }
@@ -39,7 +43,7 @@ where
 {
     inner: S,
     ratelimit: Ratelimit<A>,
-    check_limit: bool,
+    buf: Option<S::SinkItem>,
 }
 
 impl<S: Sink, A: Algorithm> Ratelimited<S, A>
@@ -56,9 +60,11 @@ where
         &mut self.inner
     }
 
-    /// Consumes this combinator, returning the underlying sink.
-    pub fn into_inner(self) -> S {
-        self.inner
+    /// Consumes this combinator, returning the underlying sink and any item
+    /// which has already been accepted by the combinator (i.e. passed the
+    /// limiter) but not yet by the underlying sink.
+    pub fn into_inner(self) -> (S, Option<S::SinkItem>) {
+        (self.inner, self.buf)
     }
 }
 
@@ -83,27 +89,38 @@ where
     type SinkError = S::SinkError;
 
     fn start_send(&mut self, item: S::SinkItem) -> StartSend<S::SinkItem, S::SinkError> {
-        if self.check_limit {
-            // Wait until we're good to go
-            if let Async::NotReady = self.ratelimit.poll()? {
+        if self.buf.is_some() {
+            // Internal buffer full, try to flush it
+            self.poll_complete()?;
+
+            if self.buf.is_some() {
+                // Internal buffer still full, time to wait
                 return Ok(AsyncSink::NotReady(item));
             }
-            self.check_limit = false;
         }
 
-        // Try to push the item into underlying sink
-        if let AsyncSink::NotReady(item) = self.inner.start_send(item)? {
+        // Check the limiter
+        if let Async::NotReady = self.ratelimit.poll()? {
             return Ok(AsyncSink::NotReady(item));
         }
 
-        // Once we have passed on an item, start checking the limit again
+        // We're good to go, accept the item
+        // It'll be flushed to the underlying sink when `poll_complete` is called
+        self.buf = Some(item);
+        // and reset the limiter future for the next item
         self.ratelimit.restart();
-        self.check_limit = true;
 
         Ok(AsyncSink::Ready)
     }
 
     fn poll_complete(&mut self) -> Poll<(), S::SinkError> {
+        if let Some(item) = self.buf.take() {
+            if let AsyncSink::NotReady(item) = self.inner.start_send(item)? {
+                self.buf = Some(item);
+                return Ok(Async::NotReady);
+            }
+        }
+
         self.inner.poll_complete()
     }
 

--- a/src/sink.rs
+++ b/src/sink.rs
@@ -1,0 +1,113 @@
+//! Rate-limiting combinator for sinks.
+
+use crate::Ratelimit;
+use futures::{Async, AsyncSink, Future, Poll, Sink, StartSend, Stream};
+use ratelimit_meter::{algorithms::Algorithm, DirectRateLimiter, NonConformance};
+use std::io;
+
+pub trait SinkExt: Sink {
+    /// Limits the rate at which items can be put into the current sink.
+    ///
+    /// Note that this combinator does not buffer any items internally but
+    /// instead limits `start_send` calls to the underlying sink.
+    fn sink_ratelimit<A: Algorithm>(self, limiter: DirectRateLimiter<A>) -> Ratelimited<Self, A>
+    where
+        Self: Sized,
+        <A as Algorithm>::NegativeDecision: NonConformance;
+}
+
+impl<S: Sink> SinkExt for S {
+    fn sink_ratelimit<A: Algorithm>(self, limiter: DirectRateLimiter<A>) -> Ratelimited<Self, A>
+    where
+        Self: Sized,
+        <A as Algorithm>::NegativeDecision: NonConformance,
+    {
+        Ratelimited {
+            inner: self,
+            ratelimit: Ratelimit::new(limiter),
+            check_limit: true,
+        }
+    }
+}
+
+/// A sink combinator which will limit the rate of items passing through.
+///
+/// This is produced by the [SinkExt::sink_ratelimit] methods.
+pub struct Ratelimited<S: Sink, A: Algorithm>
+where
+    <A as Algorithm>::NegativeDecision: NonConformance,
+{
+    inner: S,
+    ratelimit: Ratelimit<A>,
+    check_limit: bool,
+}
+
+impl<S: Sink, A: Algorithm> Ratelimited<S, A>
+where
+    <A as Algorithm>::NegativeDecision: NonConformance,
+{
+    /// Acquires a references to the underlying sink that this combinator is pushing to.
+    pub fn get_ref(&self) -> &S {
+        &self.inner
+    }
+
+    /// Acquires a mutable references to the underlying sink that this combinator is pushing to.
+    pub fn get_mut(&mut self) -> &mut S {
+        &mut self.inner
+    }
+
+    /// Consumes this combinator, returning the underlying sink.
+    pub fn into_inner(self) -> S {
+        self.inner
+    }
+}
+
+impl<S: Sink + Stream, A: Algorithm> Stream for Ratelimited<S, A>
+where
+    <A as Algorithm>::NegativeDecision: NonConformance,
+{
+    type Item = S::Item;
+    type Error = S::Error;
+
+    fn poll(&mut self) -> Poll<Option<S::Item>, S::Error> {
+        self.inner.poll()
+    }
+}
+
+impl<S: Sink, A: Algorithm> Sink for Ratelimited<S, A>
+where
+    <A as Algorithm>::NegativeDecision: NonConformance,
+    <S as Sink>::SinkError: From<io::Error>,
+{
+    type SinkItem = S::SinkItem;
+    type SinkError = S::SinkError;
+
+    fn start_send(&mut self, item: S::SinkItem) -> StartSend<S::SinkItem, S::SinkError> {
+        if self.check_limit {
+            // Wait until we're good to go
+            if let Async::NotReady = self.ratelimit.poll()? {
+                return Ok(AsyncSink::NotReady(item));
+            }
+            self.check_limit = false;
+        }
+
+        // Try to push the item into underlying sink
+        if let AsyncSink::NotReady(item) = self.inner.start_send(item)? {
+            return Ok(AsyncSink::NotReady(item));
+        }
+
+        // Once we have passed on an item, start checking the limit again
+        self.ratelimit.restart();
+        self.check_limit = true;
+
+        Ok(AsyncSink::Ready)
+    }
+
+    fn poll_complete(&mut self) -> Poll<(), S::SinkError> {
+        self.inner.poll_complete()
+    }
+
+    fn close(&mut self) -> Poll<(), S::SinkError> {
+        self.inner.close()
+    }
+}

--- a/src/sink.rs
+++ b/src/sink.rs
@@ -50,12 +50,12 @@ impl<S: Sink, A: Algorithm> Ratelimited<S, A>
 where
     <A as Algorithm>::NegativeDecision: NonConformance,
 {
-    /// Acquires a references to the underlying sink that this combinator is pushing to.
+    /// Acquires a reference to the underlying sink that this combinator is pushing to.
     pub fn get_ref(&self) -> &S {
         &self.inner
     }
 
-    /// Acquires a mutable references to the underlying sink that this combinator is pushing to.
+    /// Acquires a mutable reference to the underlying sink that this combinator is pushing to.
     pub fn get_mut(&mut self) -> &mut S {
         &mut self.inner
     }

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -1,0 +1,109 @@
+//! Rate-limiting combinator for streams.
+
+use crate::Ratelimit;
+use futures::{try_ready, Async, Future, Poll, Sink, StartSend, Stream};
+use ratelimit_meter::{algorithms::Algorithm, DirectRateLimiter, NonConformance};
+use std::io;
+
+pub trait StreamExt: Stream {
+    /// Limits the rate at which the current stream produces items.
+    ///
+    /// Note that this combinator does not buffer any items internally but
+    /// instead limits `poll` calls to the underlying stream.
+    fn ratelimit<A: Algorithm>(self, limiter: DirectRateLimiter<A>) -> Ratelimited<Self, A>
+    where
+        Self: Sized,
+        <A as Algorithm>::NegativeDecision: NonConformance;
+}
+
+impl<S: Stream> StreamExt for S {
+    fn ratelimit<A: Algorithm>(self, limiter: DirectRateLimiter<A>) -> Ratelimited<Self, A>
+    where
+        Self: Sized,
+        <A as Algorithm>::NegativeDecision: NonConformance,
+    {
+        Ratelimited {
+            inner: self,
+            ratelimit: Ratelimit::new(limiter),
+            check_limit: true,
+        }
+    }
+}
+
+/// A stream combinator which will limit the rate of items passing through.
+///
+/// This is produced by the [StreamExt::ratelimit] method.
+pub struct Ratelimited<S: Stream, A: Algorithm>
+where
+    <A as Algorithm>::NegativeDecision: NonConformance,
+{
+    inner: S,
+    ratelimit: Ratelimit<A>,
+    check_limit: bool,
+}
+
+impl<S: Stream, A: Algorithm> Ratelimited<S, A>
+where
+    <A as Algorithm>::NegativeDecision: NonConformance,
+{
+    /// Acquires a references to the underlying stream that this combinator is pulling from.
+    pub fn get_ref(&self) -> &S {
+        &self.inner
+    }
+
+    /// Acquires a mutable references to the underlying stream that this combinator is pulling from.
+    pub fn get_mut(&mut self) -> &mut S {
+        &mut self.inner
+    }
+
+    /// Consumes this combinator, returning the underlying stream.
+    pub fn into_inner(self) -> S {
+        self.inner
+    }
+}
+
+impl<S: Stream, A: Algorithm> Stream for Ratelimited<S, A>
+where
+    <A as Algorithm>::NegativeDecision: NonConformance,
+    <S as Stream>::Error: From<io::Error>,
+{
+    type Item = S::Item;
+    type Error = S::Error;
+
+    fn poll(&mut self) -> Poll<Option<S::Item>, S::Error> {
+        if self.check_limit {
+            // Wait until we're good to go
+            try_ready!(self.ratelimit.poll());
+            self.check_limit = false;
+        }
+
+        // Poll for the next item
+        let result = try_ready!(self.inner.poll());
+
+        // Once we have produced an item, start checking the limit again
+        self.ratelimit.restart();
+        self.check_limit = true;
+
+        Ok(Async::Ready(result))
+    }
+}
+
+impl<S: Stream + Sink, A: Algorithm> Sink for Ratelimited<S, A>
+where
+    <A as Algorithm>::NegativeDecision: NonConformance,
+{
+    type SinkItem = S::SinkItem;
+    type SinkError = S::SinkError;
+
+    fn start_send(&mut self, item: S::SinkItem) -> StartSend<S::SinkItem, S::SinkError> {
+        self.inner.start_send(item)
+    }
+
+    fn poll_complete(&mut self) -> Poll<(), S::SinkError> {
+        self.inner.poll_complete()
+    }
+
+    fn close(&mut self) -> Poll<(), S::SinkError> {
+        self.inner.close()
+    }
+}

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -49,12 +49,12 @@ impl<S: Stream, A: Algorithm> Ratelimited<S, A>
 where
     <A as Algorithm>::NegativeDecision: NonConformance,
 {
-    /// Acquires a references to the underlying stream that this combinator is pulling from.
+    /// Acquires a reference to the underlying stream that this combinator is pulling from.
     pub fn get_ref(&self) -> &S {
         &self.inner
     }
 
-    /// Acquires a mutable references to the underlying stream that this combinator is pulling from.
+    /// Acquires a mutable reference to the underlying stream that this combinator is pulling from.
     pub fn get_mut(&mut self) -> &mut S {
         &mut self.inner
     }

--- a/tests/ratelimit.rs
+++ b/tests/ratelimit.rs
@@ -1,7 +1,11 @@
 use futures::prelude::*;
+use futures::stream;
 use nonzero_ext::nonzero;
+use ratelimit_futures::sink::SinkExt;
+use ratelimit_futures::stream::StreamExt;
 use ratelimit_futures::Ratelimit;
 use ratelimit_meter::{DirectRateLimiter, LeakyBucket};
+use std::io;
 use std::thread;
 use std::time::{Duration, Instant};
 
@@ -55,4 +59,47 @@ fn multiple() {
         "Expected to wait some time, but waited: {:?}",
         elapsed
     );
+}
+
+#[test]
+fn stream() {
+    let i = Instant::now();
+    let lim = DirectRateLimiter::<LeakyBucket>::per_second(nonzero!(10u32));
+    let mut stream = stream::repeat::<_, io::Error>(()).ratelimit(lim).wait();
+
+    for _ in 0..10 {
+        stream.next().unwrap().unwrap();
+    }
+    assert!(i.elapsed() <= Duration::from_millis(100));
+
+    stream.next().unwrap().unwrap();
+    assert!(i.elapsed() > Duration::from_millis(100));
+    assert!(i.elapsed() <= Duration::from_millis(200));
+
+    stream.next().unwrap().unwrap();
+    assert!(i.elapsed() > Duration::from_millis(200));
+    assert!(i.elapsed() <= Duration::from_millis(300));
+}
+
+#[test]
+fn sink() {
+    let i = Instant::now();
+    let lim = DirectRateLimiter::<LeakyBucket>::per_second(nonzero!(10u32));
+    let mut sink = Vec::new()
+        .sink_map_err::<_, io::Error>(|()| unreachable!())
+        .sink_ratelimit(lim)
+        .wait();
+
+    for _ in 0..10 {
+        sink.send(()).unwrap();
+    }
+    assert!(i.elapsed() <= Duration::from_millis(100));
+
+    sink.send(()).unwrap();
+    assert!(i.elapsed() > Duration::from_millis(100));
+    assert!(i.elapsed() <= Duration::from_millis(200));
+
+    sink.send(()).unwrap();
+    assert!(i.elapsed() > Duration::from_millis(200));
+    assert!(i.elapsed() <= Duration::from_millis(300));
 }

--- a/tests/ratelimit.rs
+++ b/tests/ratelimit.rs
@@ -17,7 +17,7 @@ fn pauses() {
         }
     }
 
-    let rl = Ratelimit::new(&mut lim);
+    let rl = Ratelimit::new(lim);
     rl.wait().unwrap();
     assert!(i.elapsed() > Duration::from_millis(100));
 }
@@ -25,8 +25,8 @@ fn pauses() {
 #[test]
 fn proceeds() {
     let i = Instant::now();
-    let mut lim = DirectRateLimiter::<LeakyBucket>::per_second(nonzero!(10u32));
-    let rl = Ratelimit::new(&mut lim);
+    let lim = DirectRateLimiter::<LeakyBucket>::per_second(nonzero!(10u32));
+    let rl = Ratelimit::new(lim);
     rl.wait().unwrap();
     assert!(i.elapsed() <= Duration::from_millis(100));
 }
@@ -38,9 +38,9 @@ fn multiple() {
     let mut children = vec![];
 
     for _i in 0..20 {
-        let mut lim = lim.clone();
+        let lim = lim.clone();
         children.push(thread::spawn(move || {
-            let rl = Ratelimit::new(&mut lim);
+            let rl = Ratelimit::new(lim);
             rl.wait().unwrap();
         }));
     }


### PR DESCRIPTION
The stream and sink extension traits, impls and structs are very similar (to the point where one could easily combine them into one).
I've kept them separate though as otherwise one would always be forced to ratelimit both directions of a `Stream+Sink` object and there would be no way to limit just the `Stream` part while letting the `Sink` pass through unhindered.

Changing the limiter from `&mut` to move is a prerequisite to implementing any combinator, otherwise I would have split this into two PRs.